### PR TITLE
修改聊天窗口选择多个表情时各表情图标间会有空格或换行的bug

### DIFF
--- a/win-client/src/Modules/Session/UI/UIIMEdit.cpp
+++ b/win-client/src/Modules/Session/UI/UIIMEdit.cpp
@@ -567,7 +567,7 @@ BOOL UIIMEdit::GetContent(OUT MixedMsg& mixMsg)
 					}
 					mixMsg.m_strTextData.Insert(nPosAdd + picData.nPos, fileID);
 					mixMsg.m_strTextData.Delete(nPosAdd + picData.nPos + fileID.GetLength(), 1);
-					nPosAdd += picData.nPos + fileID.GetLength();
+					nPosAdd += fileID.GetLength() - 1;
 				}
 				else
 				{


### PR DESCRIPTION
在windows端的聊天窗口输入多个表情图标然后发送，在聊天记录窗口看到的内容中，多个表情之间会有空格或换行。修改此问题。